### PR TITLE
Bump site version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"ext-mbstring": "*",
 		"silverorange/mdb2": "^3.0.0",
 		"silverorange/admin": "^5.4.0",
-		"silverorange/site": "^9.0.0 || ^10.1.1",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
site version 11 just deprecates `getSentryClient`. inquisition doesn't use it anywhere, so version 11 is also compatible with inquisition.
