### PR TITLE
Allow site version 12 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"ext-mbstring": "*",
 		"silverorange/mdb2": "^3.0.0",
 		"silverorange/admin": "^5.4.0",
-		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Site version 12 deprecates akismet and getAkismetComment, but akismet isn't used anywhere in inquisition. So we're good to support version 12 too.
