### PR TITLE
Allow site 14 and admin 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
 		"php": ">=5.2.1",
 		"ext-mbstring": "*",
 		"silverorange/mdb2": "^3.0.0",
-		"silverorange/admin": "^5.4.0",
-		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+		"silverorange/admin": "^5.4.0 || ^6.0.0",
+		"silverorange/site": "^9.0.0 || ^10.1.1 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
Site 14 and admin 6 are both tasked with removing nategosearch. Since
inquisition doesn't use nategosearch or make any references to
the addToSearchQueue method, we are good to allow either version.